### PR TITLE
Fix CORS error

### DIFF
--- a/service/src/index.js
+++ b/service/src/index.js
@@ -64,6 +64,10 @@ app.get('/health', async (req, res) => {
 });
 
 app.post('/v1/code', async (req, res) => {
+  res.header('Access-Control-Allow-Origin', '*')
+  res.header('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+  res.header('Access-Control-Allow-Headers', 'content-type')
+
   const codeId = crypto.randomBytes(16).toString('hex');
   const {
     code, title, color, parser,


### PR DESCRIPTION
This PR adds the same response headers to the `POST` request.
If the preflight `OPTIONS` request headers does not match the subsequent `POST` request, the browser throws a generic CORS error.

![Screenshot from 2023-08-23 09-19-29](https://github.com/99mvps/mimeografo/assets/29243790/e84097f3-e5ab-43e9-b9a1-0be3a4913750)
![Screenshot from 2023-08-23 09-19-36](https://github.com/99mvps/mimeografo/assets/29243790/8087801f-a52c-4354-80c4-d603bc1d80b4)

If the response headers are the same, the browser does not complain :)

Closes #27 .